### PR TITLE
kusama bug fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ let networkDenom = "DOT";
 
 	const spinnerAccounts = new Ora({
 		text: "Fetching Accounts",
-		spinner: process.argv[2],
+		spinner: process.argv[3],
 	});
 
 	spinnerAccounts.start();
@@ -75,7 +75,7 @@ let networkDenom = "DOT";
 
 	const spinnerValidators = new Ora({
 		text: "Fetching Validators",
-		spinner: process.argv[2],
+		spinner: process.argv[3],
 	});
 
 	spinnerValidators.start();
@@ -86,7 +86,7 @@ let networkDenom = "DOT";
 
 	const spinnerActiveAndOverSub = new Ora({
 		text: "Fetching StakingInfo",
-		spinner: process.argv[2],
+		spinner: process.argv[3],
 	});
 
 	spinnerActiveAndOverSub.start();
@@ -100,7 +100,7 @@ let networkDenom = "DOT";
 
 	const spinnerStakingInfo = new Ora({
 		text: "Fetching Staking Info",
-		spinner: process.argv[2],
+		spinner: process.argv[3],
 	});
 
 	spinnerStakingInfo.start();
@@ -121,7 +121,7 @@ let networkDenom = "DOT";
 
 	const spinnerBalances = new Ora({
 		text: "Fetching Balances",
-		spinner: process.argv[2],
+		spinner: process.argv[3],
 	});
 
 	spinnerBalances.start();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16017095/123543799-e77bf600-d76d-11eb-8e0d-0f048340e386.png)

This problem was faced on running the command `node index.js kusama`

I have implemented a very simple hack fix. Earlier the spinner was referencing the third command-line argument. It worked fine in case of polkadot as the third command line argument evaluated to `undefined` but in the case of kusama, it evaluated to `kusama`. 

I have just made it such that it always references `undefined`.